### PR TITLE
Fix flex issues in dashboard

### DIFF
--- a/constellation_base/static/constellation_base/css/dashboard.css
+++ b/constellation_base/static/constellation_base/css/dashboard.css
@@ -1,0 +1,3 @@
+.dashboard .mdl-card {
+    flex-flow: column;
+}

--- a/constellation_base/templates/constellation_base/index.html
+++ b/constellation_base/templates/constellation_base/index.html
@@ -5,11 +5,11 @@
 {% block head %}
 {{ block.super }}
 {% load static %}
-<link rel="stylesheet" href="{% static 'constellation_base/css/style.css' %}">
+<link rel="stylesheet" href="{% static 'constellation_base/css/dashboard.css' %}">
 {% endblock %}
 
 {% block content %}
-<div class="mdl-grid">
+<div class="mdl-grid dashboard">
 {% for app in apps %}
 <div id="{{ app.name }}-dash" class="mdl-card mdl-cell mdl-shadow--2dp mdl-cell--6-col-desktop mdl-cell--4-col-tablet mdl-cell--12-col-phone mdl-grid">
 </div>


### PR DESCRIPTION
This commit fixes an issue which would make cards with fewer items
vertically center everything, but keep the height of the card beside it.

There's not really anything review-worthy in here, but with the release tags being a thing, I thought I'd leave it on a branch until I'm more awake.